### PR TITLE
fix: old version of bindgen makes build fail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serd-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Bastian Müller <bastian@turbolent.com>"]
 description = "Bindings to Serd, a lightweight RDF syntax library."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ categories = ["parsing", "data-structures", "api-bindings"]
 libc = "0.2.32"
 
 [build-dependencies]
-bindgen = "0.26.3"
-pkg-config = "0.3.9"
+bindgen = "0.60.1"
+pkg-config = "0.3.25"

--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,22 @@
 extern crate bindgen;
-extern crate pkg_config;
 
-use std::env;
-use std::path::PathBuf;
+use bindgen::EnumVariation;
+use std::{env, path::PathBuf};
 
 fn main() {
-    let lib = pkg_config::Config::new()
-        .atleast_version("0.28.0")
-        .probe("serd-0")
-        .unwrap();
+    let lib = pkg_config::Config::new().probe("serd-0").unwrap();
 
-    let mut builder = bindgen::Builder::default()
-        .header("wrapper.h");
+    let mut builder = bindgen::Builder::default().header("wrapper.h");
 
     for ref path in &lib.include_paths {
         builder = builder.clang_arg(format!("-I{}", path.display()));
     }
 
     let bindings = builder
-        .hide_type("max_align_t")
+        .default_enum_style(EnumVariation::Rust { non_exhaustive: true })
+        .blocklist_type("max_align_t")
+        .blocklist_item("SERD_URI_NULL")
+        .blocklist_item("SERD_NODE_NULL")
         .generate()
         .expect("Unable to generate bindings");
 
@@ -27,4 +25,3 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }
-

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 extern crate bindgen;
 
-use bindgen::EnumVariation;
 use std::{env, path::PathBuf};
 
 fn main() {
@@ -13,7 +12,6 @@ fn main() {
     }
 
     let bindings = builder
-        .default_enum_style(EnumVariation::Rust { non_exhaustive: true })
         .blocklist_type("max_align_t")
         .blocklist_item("SERD_URI_NULL")
         .blocklist_item("SERD_NODE_NULL")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,46 @@
-
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-
-extern crate libc;
+const SERD_NULL_CHUNK: SerdChunk = SerdChunk { buf: std::ptr::null(), len: 0 };
+pub const SERD_URI_NULL: SerdURI = SerdURI {
+    scheme: SERD_NULL_CHUNK,
+    authority: SERD_NULL_CHUNK,
+    path_base: SERD_NULL_CHUNK,
+    path: SERD_NULL_CHUNK,
+    query: SERD_NULL_CHUNK,
+    fragment: SERD_NULL_CHUNK,
+};
+pub const SERD_NODE_NULL: SerdNode = SerdNode {
+    buf: std::ptr::null(),
+    n_bytes: 0,
+    n_chars: 0,
+    flags: 0,
+    type_: SerdType::SERD_NOTHING,
+};
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::{CStr, CString};
 
-
     #[test]
     fn test_read() {
+        let _null_node = SERD_NODE_NULL;
+        let _null_uri = SERD_URI_NULL;
 
-        extern "C" fn process(handle: *mut ::std::os::raw::c_void,
-                              _flags: SerdStatementFlags,
-                              _graph: *const SerdNode,
-                              subject: *const SerdNode,
-                              predicate: *const SerdNode,
-                              object: *const SerdNode,
-                              object_datatype: *const SerdNode,
-                              object_lang: *const SerdNode) -> SerdStatus
-        {
+        extern "C" fn process(
+            handle: *mut ::std::os::raw::c_void,
+            _flags: SerdStatementFlags,
+            _graph: *const SerdNode,
+            subject: *const SerdNode,
+            predicate: *const SerdNode,
+            object: *const SerdNode,
+            object_datatype: *const SerdNode,
+            object_lang: *const SerdNode,
+        ) -> SerdStatus {
             assert!(!subject.is_null());
             assert!(!predicate.is_null());
             assert!(!object.is_null());
@@ -40,9 +55,18 @@ mod tests {
             assert_eq!(p.type_, SerdType::SERD_URI);
             assert_eq!(o.type_, SerdType::SERD_URI);
 
-            assert_eq!(unsafe { CStr::from_ptr(s.buf as *const _ )}.to_str().unwrap(), "urn:foo");
-            assert_eq!(unsafe { CStr::from_ptr(p.buf as *const _ )}.to_str().unwrap(), "urn:bar");
-            assert_eq!(unsafe { CStr::from_ptr(o.buf as *const _ )}.to_str().unwrap(), "urn:baz");
+            assert_eq!(
+                unsafe { CStr::from_ptr(s.buf as *const _) }.to_str().unwrap(),
+                "urn:foo"
+            );
+            assert_eq!(
+                unsafe { CStr::from_ptr(p.buf as *const _) }.to_str().unwrap(),
+                "urn:bar"
+            );
+            assert_eq!(
+                unsafe { CStr::from_ptr(o.buf as *const _) }.to_str().unwrap(),
+                "urn:baz"
+            );
 
             let count: &mut i32 = unsafe { &mut *(handle as *mut i32) };
             *count += 1;
@@ -62,16 +86,17 @@ mod tests {
 
             let mut count = 0;
 
-            let reader = serd_reader_new(SerdSyntax::SERD_NTRIPLES,
-                                         &mut count as *mut _ as *mut ::std::os::raw::c_void,
-                                         None,
-                                         None,
-                                         None,
-                                         Some(process),
-                                         None);
+            let reader = serd_reader_new(
+                SerdSyntax::SERD_NTRIPLES,
+                &mut count as *mut _ as *mut ::std::os::raw::c_void,
+                None,
+                None,
+                None,
+                Some(process),
+                None,
+            );
 
-            serd_reader_read_file_handle(reader, fd as *mut FILE,
-                                         c_path.as_ptr() as *const _);
+            serd_reader_read_file_handle(reader, fd as *mut FILE, c_path.as_ptr() as *const _);
 
             assert_eq!(count, 1);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub const SERD_NODE_NULL: SerdNode = SerdNode {
     n_bytes: 0,
     n_chars: 0,
     flags: 0,
-    type_: SerdType::SERD_NOTHING,
+    type_: SerdType_SERD_NOTHING,
 };
 
 #[cfg(test)]
@@ -51,9 +51,9 @@ mod tests {
             let p = unsafe { *predicate };
             let o = unsafe { *object };
 
-            assert_eq!(s.type_, SerdType::SERD_URI);
-            assert_eq!(p.type_, SerdType::SERD_URI);
-            assert_eq!(o.type_, SerdType::SERD_URI);
+            assert_eq!(s.type_, SerdType_SERD_URI);
+            assert_eq!(p.type_, SerdType_SERD_URI);
+            assert_eq!(o.type_, SerdType_SERD_URI);
 
             assert_eq!(
                 unsafe { CStr::from_ptr(s.buf as *const _) }.to_str().unwrap(),
@@ -71,7 +71,7 @@ mod tests {
             let count: &mut i32 = unsafe { &mut *(handle as *mut i32) };
             *count += 1;
 
-            SerdStatus::SERD_SUCCESS
+            SerdStatus_SERD_SUCCESS
         }
 
         unsafe {
@@ -87,7 +87,7 @@ mod tests {
             let mut count = 0;
 
             let reader = serd_reader_new(
-                SerdSyntax::SERD_NTRIPLES,
+                SerdSyntax_SERD_NTRIPLES,
                 &mut count as *mut _ as *mut ::std::os::raw::c_void,
                 None,
                 None,


### PR DESCRIPTION
Hi, I would like to use your bindings instead of forking/rolling my own, but as it is right now the crate does not compile because bindgen is too old. Would be nice if you could update the Cargo.toml so that the library builds again.

Thanks in advance :)